### PR TITLE
feat: add bpmn diagram, users and system module

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,8 +28,8 @@ import { CoreModule } from './core/core.module';
 import { HomeModule } from './home/home.module';
 import { LoginModule } from './login/login.module';
 import { SettingsModule } from './settings/settings.module';
-// import { SystemModule } from './system/system.module';
-// import { UsersModule } from './users/users.module';
+import { SystemModule } from './system/system.module';
+import { UsersModule } from './users/users.module';
 import { PaymentHubModule } from './payment-hub/paymenthub.module';
 
 
@@ -58,8 +58,8 @@ export function initConfig(config: AppConfig) {
     HomeModule,
     LoginModule,
     SettingsModule,
-    // SystemModule,
-    // UsersModule,
+    SystemModule,
+    UsersModule,
     PaymentHubModule,
     AppRoutingModule,
   ],

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -11,21 +11,16 @@
 
   <nav mat-tab-nav-bar backgroundColor="primary" class="ml-1">
 
-    <!-- <a mat-tab-link class="tab-link" [matMenuTriggerFor]="institutionMenu" #institutionMenuTrigger="matMenuTrigger">
-      <fa-icon class="mr-05" icon="university" size="lg"></fa-icon>
-      Institution
-    </a> -->
-
     <span fxHide.lt-lg="true">
 
       <a mat-tab-link class="tab-link" [routerLink]="['/paymenthubee']">
         <fa-icon class="mr-05" icon="money-bill-alt" size="lg"></fa-icon>
         Payment Hub EE
       </a>
-      <!-- <a mat-tab-link class="tab-link" [matMenuTriggerFor]="adminMenu" #adminMenuTrigger="matMenuTrigger">
+      <a mat-tab-link class="tab-link" [matMenuTriggerFor]="adminMenu" #adminMenuTrigger="matMenuTrigger">
         <fa-icon class="mr-05" icon="shield-alt" size="lg"></fa-icon>
         Admin
-      </a> -->
+      </a>
     </span>
 
   </nav>

--- a/src/app/payment-hub/paymenthub.component.html
+++ b/src/app/payment-hub/paymenthub.component.html
@@ -7,6 +7,7 @@
       <div fxFlex="50%">
 
         <mat-nav-list>
+
           <mat-list-item [routerLink]="['incomingtransactions']">
             <mat-icon matListIcon>
               <fa-icon icon="search" size="sm"></fa-icon>
@@ -14,6 +15,15 @@
             <h4 matLine>Search Incoming Transactions</h4>
             <p matLine>Advanced search option for incoming transactions</p>
           </mat-list-item>
+
+        </mat-nav-list>
+
+      </div>
+
+      <div fxFlex="50%">
+
+        <mat-nav-list>
+
           <mat-list-item [routerLink]="['outgoingtransactions']">
             <mat-icon matListIcon>
               <fa-icon icon="search" size="sm"></fa-icon>

--- a/src/app/payment-hub/paymenthub.module.ts
+++ b/src/app/payment-hub/paymenthub.module.ts
@@ -1,5 +1,6 @@
 /** Angular Imports */
 import { NgModule } from '@angular/core';
+import { MatDialogModule } from '@angular/material/dialog';
 
 /** Custom Modules */
 import { SharedModule } from '../shared/shared.module';
@@ -10,6 +11,7 @@ import { IncomingTransactionsComponent } from './transactions/incoming/incoming-
 import { OutgoingTransactionsComponent } from './transactions/outgoing/outgoing-transactions.component';
 import { PaymentHubComponent } from './paymenthub.component';
 import { TransactionDetailsComponent } from './transactions/transaction-details.component';
+import { BpmnDialogComponent } from './transactions/bpmn-dialog/bpmn-dialog.component';
 
 
 /**
@@ -19,6 +21,7 @@ import { TransactionDetailsComponent } from './transactions/transaction-details.
  */
 @NgModule({
   imports: [
+    MatDialogModule,
     SharedModule,
     PaymentHubRoutingModule
   ],
@@ -26,10 +29,12 @@ import { TransactionDetailsComponent } from './transactions/transaction-details.
     IncomingTransactionsComponent,
     OutgoingTransactionsComponent,
     TransactionDetailsComponent,
-    PaymentHubComponent
+    PaymentHubComponent,
+    BpmnDialogComponent
   ],
   entryComponents: [
     PaymentHubComponent,
+    BpmnDialogComponent
   ]
 })
 export class PaymentHubModule { }

--- a/src/app/payment-hub/transactions/bpmn-dialog/bpmn-dialog.component.html
+++ b/src/app/payment-hub/transactions/bpmn-dialog/bpmn-dialog.component.html
@@ -1,0 +1,16 @@
+<h2 mat-dialog-title>BPMN Diagram ({{datasource.transaction.workflowInstanceKey}})</h2>
+
+<mat-dialog-content>
+
+<!-- TODO: Update when API is available. -->
+<!-- Sample SVG -->
+<svg width="400" height="180">
+  <rect x="50" y="20" width="150" height="150" style="fill:blue;stroke:pink;stroke-width:5;opacity:0.5" />
+  Sorry, your browser does not support inline SVG.  
+</svg>
+
+</mat-dialog-content>
+
+<mat-dialog-actions>
+    <button mat-raised-button color="warn"  [mat-dialog-close]="">Close</button>
+</mat-dialog-actions>

--- a/src/app/payment-hub/transactions/bpmn-dialog/bpmn-dialog.component.spec.ts
+++ b/src/app/payment-hub/transactions/bpmn-dialog/bpmn-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BpmnDialogComponent } from './bpmn-dialog.component';
+
+describe('BpmnDialogComponent', () => {
+  let component: BpmnDialogComponent;
+  let fixture: ComponentFixture<BpmnDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BpmnDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BpmnDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/payment-hub/transactions/bpmn-dialog/bpmn-dialog.component.ts
+++ b/src/app/payment-hub/transactions/bpmn-dialog/bpmn-dialog.component.ts
@@ -1,0 +1,21 @@
+/** Angular Imports */
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+  selector: 'mifosx-bpmn-dialog',
+  templateUrl: './bpmn-dialog.component.html',
+  styleUrls: ['./bpmn-dialog.component.scss']
+})
+export class BpmnDialogComponent implements OnInit {
+
+  datasource: any;
+
+  constructor(public dialogRef: MatDialogRef<BpmnDialogComponent>,
+  @Inject(MAT_DIALOG_DATA) public data: any) { 
+  	this.datasource = data.datasource;
+  }
+
+  ngOnInit() {
+  }
+}

--- a/src/app/payment-hub/transactions/transaction-details.component.html
+++ b/src/app/payment-hub/transactions/transaction-details.component.html
@@ -1,3 +1,9 @@
+<div class="container m-b-20" fxLayout="row" fxLayoutAlign="end" fxLayoutGap="20px">
+  <button mat-raised-button color="primary" (click)="openDialog()">
+    BPMN Diagram
+  </button>
+</div>
+
 <div class="container">
   <mat-grid-list cols="2" rowHeight="350">
     <mat-grid-tile [colspan]="1"

--- a/src/app/payment-hub/transactions/transaction-details.component.ts
+++ b/src/app/payment-hub/transactions/transaction-details.component.ts
@@ -9,6 +9,9 @@ import { formatDate, formatUTCDate } from './helper/date-format.helper';
 import { DfspEntry } from './model/dfsp.model';
 import { transactionStatusData as statuses } from './helper/transaction.helper';
 
+/** Dialog Components */
+import { BpmnDialogComponent } from './bpmn-dialog/bpmn-dialog.component'
+
 /**
  * View transaction component.
  */
@@ -122,5 +125,13 @@ export class TransactionDetailsComponent implements OnInit {
 
     const elements = this.transactionStatusData.filter((option) => option.value === status);
     return elements.length > 0 ? elements[0].css : undefined;
+  }
+
+  openDialog() {
+    const bpmnDialogRef = this.dialog.open( BpmnDialogComponent, {
+      data: {
+        datasource: this.datasource
+      },
+    });
   }
 }


### PR DESCRIPTION
added bpmn diagram in transaction details, users and system module.
![Screenshot from 2020-06-02 17-09-49](https://user-images.githubusercontent.com/45865775/83516849-77ad2480-a4f5-11ea-8c84-228b89251b77.png)
![Screenshot from 2020-06-02 17-09-57](https://user-images.githubusercontent.com/45865775/83516850-78de5180-a4f5-11ea-8aaf-7e4d0739855d.png)
![Screenshot from 2020-06-02 17-15-36](https://user-images.githubusercontent.com/45865775/83516852-7a0f7e80-a4f5-11ea-971a-3644a2076835.png)
Minor change to UI - 
![Screenshot from 2020-06-02 17-27-30](https://user-images.githubusercontent.com/45865775/83517396-73353b80-a4f6-11ea-9d9d-499d28637753.png)
