### PR TITLE
fix: resolve env.phee.version undefined error in local setup

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,7 +9,7 @@ import env from './.env';
 export let environment = {
   name: 'dev',
   production: false,
-  version: env.phee.version + '-dev',
+  version: env.npm_package_version + '-dev' ,
   backend: {
     operations: window['env']['serverApiUrlOps'] || 'http://ops.mifos.gazelle.test/api/v1',
     signatureApiUrl: window['env']['signatureApiUrl'] || 'http://ops.mifos.gazelle.test/api/v1',


### PR DESCRIPTION
## Description
This PR fixes a bug where `environment.ts` incorrectly accesses `env.phee.version` 
which does not exist in the auto-generated `.env.ts` file, causing a TypeScript 
compile error on local setup.

Related issue: #106

No Jira ticket — this is a community contributor bug fix.

Changed `env.phee.version` to `env.npm_package_version` which is the actual 
property exposed by `npm run env` via ngx-scripts.

## Checklist
- [x] Followed the PR title naming convention mentioned above.
- [ ] Design related bullet points or design document link related to this PR added in the description above.
- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.
- [x] Create/update unit or integration tests for verifying the changes made.
- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable
- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing